### PR TITLE
:construction_worker: Change Molecule CI schedule

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: 0 12 */2 * *
+    - cron: 30 20 */2 * *
 jobs:
   molecule-test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Attempt to avoid galaxy timeouts by running molecule at a different time