### PR TITLE
:rotating_light: Ignore Ansible lint rule `galaxy[no-changelog]`

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,5 @@
 ---
+skip_list:
+  - galaxy[no-changelog]
 exclude_paths:
   - .github/


### PR DESCRIPTION
Changelogs are in GitHub releases