### PR TITLE
Upgrade molecule to 5.0.1 to fix ansible-community/molecule#3903

### DIFF
--- a/.github/molecule-requirements.txt
+++ b/.github/molecule-requirements.txt
@@ -1,5 +1,5 @@
 ansible==7.1.0
-molecule==4.0.4
+molecule==5.0.1
 molecule-docker==2.1.0
 pytest-molecule==2.0.0
 pytest-testinfra==7.0.0


### PR DESCRIPTION
This fixes molecules ansible-compat issue described in https://github.com/ansible-community/molecule/issues/3903